### PR TITLE
Add temp workaround for spark stream job process delay

### DIFF
--- a/spark/spark-stream-job-processing-delay.md
+++ b/spark/spark-stream-job-processing-delay.md
@@ -61,5 +61,7 @@ This is an indication that the problem happens during writing message to externa
 2. If the Spark job is reading and/or writing to WASB frequently, it can cause subsequent micro-batches to lag
 
    The WASB implementation of Filesystem.listStatus is very slow due to O(n!) algorithm to remove duplicates and uses too much memory due to the extra conversion from BlobListItem to FileMetadata to FileStatus. It takes over 30 minutes to list 700,000 files. So if ListBlobs is being called aggressively by SparkSQL every micro-batch, it will cause subsequent micro-batches to lag behind resulting in what you experience as high scheduling delays. This patch https://issues.apache.org/jira/browse/HADOOP-15547 fixes the issue, but if it is missing in your environment, ListBlobs will experience high latency. Also, even if you delete files every hour, the listing in the backend has to iterate over all rows (including deleted) because garbage collection process didn’t kick in yet. While the patch might solve bulk of your problem, the latter issue might kick in and cause you to still lag behind in stream processing of batches.  
+   
+   Temp Workaround (before the HADOOP-15547 fix): use HDFS as the check point location: Set checkpointDirectory to something like: "hdfs://mycluster/checkpoint"
 
 


### PR DESCRIPTION
Signed-off-by: Shanyu Zhao <shzhao@microsoft.com>