### PR TITLE
Add the "Use Interactive Mode" in hive TSG

### DIFF
--- a/hive/hive-view-inaccessible.md
+++ b/hive/hive-view-inaccessible.md
@@ -31,9 +31,9 @@ From hive server logs ```/var/log/hive``` identified following error to confirm 
 /var/log/hive has error
 `ERROR [Curator-Framework-0]: curator.ConnectionState (ConnectionState.java:checkTimeouts(200)) - Connection timed out for connection string (zk0-cluster.cloud.wbmi.com:2181,zk1-cluster.cloud.wbmi.com:2181,zk2-cluster.cloud.wbmi.com:2181) and timeout (15000) / elapsed (21852)` 
 ```
-3. **If it is a LLAP cluster**. Check if "Use Interactive Mode" is enabled. You can see this config from Ambari portal. Make sure it's on.
+3. **If it is an LLAP cluster**. Check if "Use Interactive Mode" is enabled. You can see this config from Ambari portal. Make sure it's on.
 
-   **If it is not a LLAP cluster, skip this check.**
+   **If it is not an LLAP cluster, skip this check.**
    
 4. Check if Zookeeper has a entry of znode for hiveserver2
 


### PR DESCRIPTION
CX saw the "Use Interactive Mode" was off from their cluster. Which is causing the hive view inaccessible issue. Because incorrect zookeeper namespace would be used if the switch is off.