### PR TITLE
Updated ambari-agent-heartbeat-lost.html

### DIFF
--- a/ambari/ambari-agent-heartbeat-lost.html
+++ b/ambari/ambari-agent-heartbeat-lost.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset=utf-8>
     <title>Redirecting...</title>
-    <link rel=canonical href="https://docs.microsoft.com/en-us/azure/hdinsight/hadoop/apache-ambari-troubleshoot-fivezerotwo-error">
-    <meta http-equiv=refresh content="1; url=https://docs.microsoft.com/en-us/azure/hdinsight/hadoop/apache-ambari-troubleshoot-fivezerotwo-error">
+    <link rel=canonical href="https://docs.microsoft.com/en-us/azure/hdinsight/hadoop/apache-ambari-troubleshoot-heartbeat-issues">
+    <meta http-equiv=refresh content="1; url=https://docs.microsoft.com/en-us/azure/hdinsight/hadoop/apache-ambari-troubleshoot-heartbeat-issues">
   </head>
   <body>
     <h1>Redirecting...</h1>
-    <a href="https://docs.microsoft.com/en-us/azure/hdinsight/hadoop/apache-ambari-troubleshoot-fivezerotwo-error">Click here if you are not redirected.</a>
+    <a href="https://docs.microsoft.com/en-us/azure/hdinsight/hadoop/apache-ambari-troubleshoot-heartbeat-issues">Click here if you are not redirected.</a>
   </body>
 </html>
 


### PR DESCRIPTION
It redirects to https://docs.microsoft.com/en-us/azure/hdinsight/hadoop/apache-ambari-troubleshoot-fivezerotwo-error. 
Changed it to redirect to correct page in docs platform: https://docs.microsoft.com/en-us/azure/hdinsight/hadoop/apache-ambari-troubleshoot-heartbeat-issues